### PR TITLE
Add lockFile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.out
 example/**/charts
 example/**/.cache
 example/*/requirements.lock
+!example/cert-manager/requirements.lock

--- a/example/cert-manager/cert-manager-chart.yaml
+++ b/example/cert-manager/cert-manager-chart.yaml
@@ -8,3 +8,4 @@ chart: cert-manager
 version: 0.9.1
 valueFiles:
 - values.yaml
+lockFile: requirements.lock

--- a/example/cert-manager/requirements.lock
+++ b/example/cert-manager/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: webhook
+  repository: file://webhook
+  version: v0.1.0
+- name: cainjector
+  repository: file://cainjector
+  version: v0.1.0
+digest: sha256:6146778d6e3e23fd10a36664c0ae25e514d6e2b025053854b172a914e7d553a0
+generated: "2020-06-30T09:52:20.363110549-04:00"


### PR DESCRIPTION
This should address issue #1.

If a `ChartRenderer` spec contains a `lockFile` key pointing to a `requirements.lock` file (the source filename doesn't matter), it will be copied to the unpacked chart as `requirements.lock`.

`LoadChart` now delegates most of its work to Helm's download manager's `Build()` method, which includes logic to check `requirements.lock` validity.

Let me know if there's anything else I can do to help get this landed!