### PR TITLE
Add lockFile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.out
 example/**/charts
 example/**/.cache
 example/*/requirements.lock
+!example/cert-manager/requirements.lock

--- a/example/cert-manager/cert-manager-chart.yaml
+++ b/example/cert-manager/cert-manager-chart.yaml
@@ -8,3 +8,4 @@ chart: cert-manager
 version: 0.9.1
 valueFiles:
 - values.yaml
+lockFile: requirements.lock

--- a/example/cert-manager/requirements.lock
+++ b/example/cert-manager/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: webhook
+  repository: file://webhook
+  version: v0.1.0
+- name: cainjector
+  repository: file://cainjector
+  version: v0.1.0
+digest: sha256:6146778d6e3e23fd10a36664c0ae25e514d6e2b025053854b172a914e7d553a0
+generated: "2020-06-30T09:52:20.363110549-04:00"

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -356,13 +356,17 @@ func (h *Helm) LoadChart(ref *LoadChartConfig) (c *chart.Chart, err error) {
 	}
 
 	lock, err := chartutil.LoadRequirementsLock(c)
-	if err != nil && err != chartutil.ErrLockfileNotFound {
-		return nil, err
+	if err == chartutil.ErrLockfileNotFound {
+		err = nil
+	} else if err != nil {
+		return
 	}
 
 	req, err := chartutil.LoadRequirements(c)
-	if err != nil && err != chartutil.ErrRequirementsNotFound {
-		return nil, err
+	if err == chartutil.ErrRequirementsNotFound {
+		err = nil
+	} else if err != nil {
+		return
 	}
 
 	if req != nil {


### PR DESCRIPTION
This should address issue #1.

If a `ChartRenderer` spec contains a `lockFile` key pointing to a `requirements.lock` file (the source filename doesn't matter), it will be injected into the chart as `requirements.lock`.

`LoadChart` now includes logic to check `requirements.lock` validity.

Let me know if there's anything else I can do to help get this landed!